### PR TITLE
Fix node 10 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 12.x
+          node-version: 10.x
       - name: Install yarn
         run: npm install -g yarn
       - name: Install dependencies

--- a/index.js
+++ b/index.js
@@ -5,6 +5,9 @@ const TAG_SPLIT = /([^<]+)?(<[^>]+>)*/;
 const mightHaveTag = (str) =>
   str ? str.indexOf('<') < str.indexOf('>') : false;
 
+// Node 10 Support
+const flattened = arr => [].concat(...arr);
+
 const splitTags = (str) => {
   if (!mightHaveTag(str)) return [str];
 
@@ -37,7 +40,7 @@ const splitTags = (str) => {
     result = result.map(splitTags);
   }
 
-  return result.flat().filter(Boolean);
+  return flattened(result).filter(Boolean);
 };
 
 const parseHBS = (node, indexInParent, parent) => {
@@ -53,7 +56,7 @@ const parseHBS = (node, indexInParent, parent) => {
 
   // When text nodes also have html on them, such as "text</endingTag>",
   // split those up as well
-  const lines = node.value.split('\n').map(splitTags).flat();
+  const lines = flattened(node.value.split('\n').map(splitTags));
 
   const toInsert = [];
   lines.forEach((line) => {


### PR DESCRIPTION
According to [package.json](https://github.com/josemarluedke/remark-hbs/blob/master/package.json#L40),
Node 10 is supposed to be supported.
Support of `flat` is introduced in node 11.
If you plan to drop support for node 10, can you please publish a `v0.4.1` with this fix before bumping major version?
Thanks